### PR TITLE
Make sure every fork()ed subprocess has a watchdog timer.

### DIFF
--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -113,7 +113,7 @@ void close_all_connections(Connection *connections, int connections_length) {
 // At 150k tests per day, this one sleep(2) wastes 83 hours of peoples'
 // lives every day.
 // TODO: solve the race conditions some other way.
-#define LOSE_RACE_CONDITION 2
+const static int RACE_CONDITION_WAIT_TIME = 2;
 
 /**
  * Perform the C2S Throughput test. This test intends to measure throughput
@@ -427,7 +427,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         close_all_connections(c2s_conns, streamsNum);
         // Don't capture more than 14 seconds of packet traces:
         //   2 seconds of sleep + 10 seconds of test + 2 seconds of slop
-        alarm(testDuration + LOSE_RACE_CONDITION + 2);
+        alarm(testDuration + RACE_CONDITION_WAIT_TIME + 2);
         log_println(
             5,
             "C2S test Child %d thinks pipe() returned fd0=%d, fd1=%d",
@@ -473,7 +473,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   create_client_logdir((struct sockaddr *) &cli_addr[0], clilen,
                        options->c2s_logname, sizeof(options->c2s_logname),
                        namesuffix, sizeof(namesuffix));
-  sleep(LOSE_RACE_CONDITION);
+  sleep(RACE_CONDITION_WAIT_TIME);
   // Reset alarm() again. This 10 sec test should finish before this signal is
   // generated, but sleep() can render existing alarm()s invalid, and alarm() is
   // our watchdog timer.

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -109,6 +109,12 @@ void close_all_connections(Connection *connections, int connections_length) {
   }
 }
 
+// How long to sleep to avoid a race condition.  This is a bad hack.
+// At 150k tests per day, this one sleep(2) wastes 83 hours of peoples'
+// lives every day.
+// TODO: solve the race conditions some other way.
+#define LOSE_RACE_CONDITION 2
+
 /**
  * Perform the C2S Throughput test. This test intends to measure throughput
  * from the client to the server by performing a 10 seconds memory-to-memory
@@ -421,7 +427,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         close_all_connections(c2s_conns, streamsNum);
         // Don't capture more than 14 seconds of packet traces:
         //   2 seconds of sleep + 10 seconds of test + 2 seconds of slop
-        alarm(14);
+        alarm(testDuration + LOSE_RACE_CONDITION + 2);
         log_println(
             5,
             "C2S test Child %d thinks pipe() returned fd0=%d, fd1=%d",
@@ -467,10 +473,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   create_client_logdir((struct sockaddr *) &cli_addr[0], clilen,
                        options->c2s_logname, sizeof(options->c2s_logname),
                        namesuffix, sizeof(namesuffix));
-  // At 150k tests per day, this one sleep(2) wastes 83 hours of peoples'
-  // lives every day.
-  // TODO: solve the race conditions some other way.
-  sleep(2);
+  sleep(LOSE_RACE_CONDITION);
   // Reset alarm() again. This 10 sec test should finish before this signal is
   // generated, but sleep() can render existing alarm()s invalid, and alarm() is
   // our watchdog timer.

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -419,6 +419,9 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
       if ((c2s_childpid = fork()) == 0) {
         close(testOptions->c2ssockfd);
         close_all_connections(c2s_conns, streamsNum);
+        // Don't capture more than 14 seconds of packet traces:
+        //   2 seconds of sleep + 10 seconds of test + 2 seconds of slop
+        alarm(14);
         log_println(
             5,
             "C2S test Child %d thinks pipe() returned fd0=%d, fd1=%d",

--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -382,6 +382,9 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
           log_println(0, "S2C test error: can't create pipe.");
         } else {
           if ((s2c_childpid = fork()) == 0) {
+            // Don't capture more than 12 seconds of packet traces:
+            //   10 second test + 2 seconds of slop
+            alarm(12);
             close(testOptions->s2csockfd);
             for (i = 0; i < streamsNum; i++) {
               close(xmitsfd[i].socket);

--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -384,7 +384,7 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
           if ((s2c_childpid = fork()) == 0) {
             // Don't capture more than 12 seconds of packet traces:
             //   10 second test + 2 seconds of slop
-            alarm(12);
+            alarm(testDuration + 2);
             close(testOptions->s2csockfd);
             for (i = 0; i < streamsNum; i++) {
               close(xmitsfd[i].socket);


### PR DESCRIPTION
Adds two alarm() calls which will act as watchdog timers for the c2s process to prevent runaway packet captures.