### PR TITLE
Fixed: server freeze and other SSL, error handling, and buffer bugs

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -21,7 +21,7 @@
 #define PROTOLOGFILE "web100srvprotocol.log"  // name of protocol log file
 #define PROTOLOGPREFIX "web100srvprotocol_"  // prefix for protocol log file
 #define PROTOLOGSUFFIX ".log"  // suffix for protocol validation log file
-#define FILENAME_SIZE 256
+#define FILENAME_SIZE 1024
 /* #define PROTOLOGDIR "protocollog"     Protocol log dir */
 void log_init(char* progname, int debuglvl);
 void set_debuglvl(int debuglvl);
@@ -49,8 +49,8 @@ int zlib_def(char *src_fn);
  * Format used to exchange meta test data between client->server.
  * */
 struct metaentry {
-  char key[64];  // key name
-  char value[256];  // value associated with this meta key
+  char key[1024];  // key name
+  char value[1024];  // value associated with this meta key
   struct metaentry* next;  // pointer to next link
 };
 
@@ -65,6 +65,8 @@ struct throughputSnapshot {
  * These values (most) are thes logged in the
  *  meta data file created  for every session
  * */
+// TODO: ensure every write to a char array will always result in a
+//       null-terminated string of less than the buffer size.
 struct metadata {
   char c2s_snaplog[FILENAME_SIZE];  // C->S test Snaplog file name
   char c2s_ndttrace[FILENAME_SIZE];  // C->S NDT trace file name
@@ -72,19 +74,19 @@ struct metadata {
   char s2c_ndttrace[FILENAME_SIZE];  // S->C NDT trace file name
   char CPU_time[FILENAME_SIZE];  // CPU time file
   char web_variables_log[FILENAME_SIZE];  // web100/web10g variables log
-  char summary[256];  // Summary data
-  char date[32];  // Date and,
-  char time[16];  // time
-  char client_ip[64];  // Client IP Address
+  char summary[1024];  // Summary data
+  char date[1024];  // Date and,
+  char time[1024];  // time
+  char client_ip[1024];  // Client IP Address
   struct sockaddr_storage c_addr;  // client socket details, not logged
-  char client_name[64];  // client's host-name
-  char client_os[32];  // client OS name
-  char client_browser[32];  // client's browser name
-  char client_application[32];  // client application name
+  char client_name[1024];  // client's host-name
+  char client_os[1024];  // client OS name
+  char client_browser[1024];  // client's browser name
+  char client_application[1024];  // client application name
   int ctl_port;  // ctl port
-  char server_ip[64];  // server IP address
-  char server_name[64];  // server's host-name
-  char server_os[32];  // server os name
+  char server_ip[1024];  // server IP address
+  char server_name[1024];  // server's host-name
+  char server_os[1024];  // server os name
   int family;  // IP family
   struct metaentry* additional;  // all other additional data
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -65,8 +65,10 @@ struct throughputSnapshot {
  * These values (most) are thes logged in the
  *  meta data file created  for every session
  * */
-// TODO: ensure every write to a char array will always result in a
-//       null-terminated string of less than the buffer size.
+// TODO: ensure every write to a char array in meta will always result in a
+//       null-terminated string of less than the buffer size.  This will also
+//       require auditing of FILENAME_SIZE and the constants used in
+//       writeMeta() in web100srv.c
 struct metadata {
   char c2s_snaplog[FILENAME_SIZE];  // C->S test Snaplog file name
   char c2s_ndttrace[FILENAME_SIZE];  // C->S NDT trace file name

--- a/src/test_meta_srv.c
+++ b/src/test_meta_srv.c
@@ -48,7 +48,7 @@ void addAdditionalMetaBoolEntry(struct metaentry **ptr, char* key, int value);
 int test_meta_srv(Connection *ctl, tcp_stat_agent *agent,
                   TestOptions *testOptions, int conn_options, Options* options) {
   int j;
-  int64_t err;
+  int err;
   int msgLen, msgType;
   char buff[BUFFSIZE + 1];
   struct metaentry *new_entry = NULL;

--- a/src/test_meta_srv.c
+++ b/src/test_meta_srv.c
@@ -90,7 +90,7 @@ int test_meta_srv(Connection *ctl, tcp_stat_agent *agent,
                          testOptions->connection_flags);
       if (err) {
         // message reading error
-        log_println(0, "Protocol error!");
+        log_println(0, "Protocol error! (%d)", err);
         snprintf(buff, sizeof(buff),
                  "Server (META test): Invalid meta data received");
         send_json_message_any(ctl, MSG_ERROR, buff, strlen(buff),

--- a/src/web100srv_unit_tests.c
+++ b/src/web100srv_unit_tests.c
@@ -175,7 +175,7 @@ void run_ssl_test(void test_fn(int port, const char *hostname)) {
   pid_t server_pid;
   int server_exit_code;
   int err;
-  char *server_args[] = {"--tls_port", tls_port_string, "--private_key", private_key_file, "--certificate", certificate_file, NULL};
+  char *server_args[] = {"--tls_port", tls_port_string, "--private_key", private_key_file, "--certificate", certificate_file, "--snaplog", "--log_dir", "/tmp", NULL};
   // Set up certificates
   make_certificate_files(private_key_file, certificate_file);
   // Start the server with the right mode
@@ -286,7 +286,8 @@ void test_queuing() {
   const int num_clients = 20;
   char *server_args[] = {"--max_clients=5", "--tls_port", tls_port_string,
                          "--private_key", private_key_file,
-                         "--certificate", certificate_file, "--multiple", NULL};
+                         "--certificate", certificate_file, "--multiple",
+                         "--disable_extended_tests", NULL};
   choose_random_ports(&port, &tls_port);
   sprintf(tls_port_string, "%d", tls_port);
   make_certificate_files(private_key_file, certificate_file);


### PR DESCRIPTION
  The bug where the server would freeze sometimes. (accept() was getting interrupted)
  The bug where SSL sockets would cause the META test to fail.
  The bug where the OS name got cut off at 32 chars, almost certainly clobbering a pointer which was stored later in the same struct.
  readn_any's error handling, because SSL_read can return an error which literally means "please call SSL_read".
  run_meta_test_srv's error handling now correctly logs the error