### PR TITLE
Save the tls and websocket keys unconditionally.

### DIFF
--- a/src/test_meta_srv.c
+++ b/src/test_meta_srv.c
@@ -22,10 +22,6 @@
 #include "strlutils.h"
 #include "websocket.h"
 
-void addAdditionalMetaEntry(struct metaentry **ptr, char* key, char* value);
-void addAdditionalMetaIntEntry(struct metaentry **ptr, char* key, int value);
-void addAdditionalMetaBoolEntry(struct metaentry **ptr, char* key, int value);
-
 /**
  * Performs the META test.
  * @param ctl Client control Connection
@@ -51,7 +47,6 @@ int test_meta_srv(Connection *ctl, tcp_stat_agent *agent,
   int err;
   int msgLen, msgType;
   char buff[BUFFSIZE + 1];
-  struct metaentry *new_entry = NULL;
   char *value, *jsonMsgValue;
 
   // protocol validation logs
@@ -157,26 +152,22 @@ int test_meta_srv(Connection *ctl, tcp_stat_agent *agent,
         snprintf(meta.client_browser, sizeof(meta.client_browser), "%s", value);
       }
 
-      addAdditionalMetaEntry(&new_entry, buff, value);
+      addAdditionalMetaEntry(buff, value);
     }
     if (testOptions->c2sextopt) {
-      addAdditionalMetaIntEntry(&new_entry, "ext.c2s.duration", options->c2s_duration);
-      addAdditionalMetaBoolEntry(&new_entry, "ext.c2s.throughputsnaps", options->c2s_throughputsnaps);
-      addAdditionalMetaIntEntry(&new_entry, "ext.c2s.snapsdelay", options->c2s_snapsdelay);
-      addAdditionalMetaIntEntry(&new_entry, "ext.c2s.snapsoffset", options->c2s_snapsoffset);
-      addAdditionalMetaIntEntry(&new_entry, "ext.c2s.streamsnum", options->c2s_streamsnum);
+      addAdditionalMetaIntEntry("ext.c2s.duration", options->c2s_duration);
+      addAdditionalMetaBoolEntry("ext.c2s.throughputsnaps", options->c2s_throughputsnaps);
+      addAdditionalMetaIntEntry("ext.c2s.snapsdelay", options->c2s_snapsdelay);
+      addAdditionalMetaIntEntry("ext.c2s.snapsoffset", options->c2s_snapsoffset);
+      addAdditionalMetaIntEntry("ext.c2s.streamsnum", options->c2s_streamsnum);
     }
     if (testOptions->s2cextopt) {
-      addAdditionalMetaIntEntry(&new_entry, "ext.s2c.duration", options->s2c_duration);
-      addAdditionalMetaBoolEntry(&new_entry, "ext.s2c.throughputsnaps", options->s2c_throughputsnaps);
-      addAdditionalMetaIntEntry(&new_entry, "ext.s2c.snapsdelay", options->s2c_snapsdelay);
-      addAdditionalMetaIntEntry(&new_entry, "ext.s2c.snapsoffset", options->s2c_snapsoffset);
-      addAdditionalMetaIntEntry(&new_entry, "ext.s2c.streamsnum", options->s2c_streamsnum);
+      addAdditionalMetaIntEntry("ext.s2c.duration", options->s2c_duration);
+      addAdditionalMetaBoolEntry("ext.s2c.throughputsnaps", options->s2c_throughputsnaps);
+      addAdditionalMetaIntEntry("ext.s2c.snapsdelay", options->s2c_snapsdelay);
+      addAdditionalMetaIntEntry("ext.s2c.snapsoffset", options->s2c_snapsoffset);
+      addAdditionalMetaIntEntry("ext.s2c.streamsnum", options->s2c_streamsnum);
     }
-    addAdditionalMetaBoolEntry(&new_entry, "websockets",
-			       (testOptions->connection_flags & WEBSOCKET_SUPPORT));
-    addAdditionalMetaBoolEntry(&new_entry, "tls",
-			       (testOptions->connection_flags & TLS_SUPPORT));
 
     // Finalize test by sending appropriate message, and setting status
     if (send_json_message_any(ctl, TEST_FINALIZE, "", 0,
@@ -195,27 +186,4 @@ int test_meta_srv(Connection *ctl, tcp_stat_agent *agent,
     setCurrentTest(TEST_NONE);
   }
   return 0;
-}
-
-void addAdditionalMetaEntry(struct metaentry **ptr, char* key, char* value) {
-  if (*ptr) {
-    (*ptr)->next = (struct metaentry *) malloc(sizeof(struct metaentry));
-    (*ptr) = (*ptr)->next;
-  } else {
-    (*ptr) = (struct metaentry *) malloc(sizeof(struct metaentry));
-    meta.additional = (*ptr);
-  }
-  (*ptr)->next = NULL;  // ensure meta list ends here
-  snprintf((*ptr)->key, sizeof((*ptr)->key), "%s", key);
-  snprintf((*ptr)->value, sizeof((*ptr)->value), "%s", value);
-}
-
-void addAdditionalMetaIntEntry(struct metaentry **ptr, char* key, int value) {
-  char tmpbuff[256];
-  snprintf(tmpbuff, sizeof(tmpbuff), "%d", value);
-  addAdditionalMetaEntry(ptr, key, tmpbuff);
-}
-
-void addAdditionalMetaBoolEntry(struct metaentry **ptr, char* key, int value) {
-  addAdditionalMetaEntry(ptr, key, value ? "true" : "false");
 }

--- a/src/testoptions.c
+++ b/src/testoptions.c
@@ -395,6 +395,9 @@ int initialize_tests(Connection *ctl, TestOptions *options, char *buff,
   if (useropt & TEST_META) {
     add_test_to_suite(&first, buff, buff_strlen, TEST_META);
   }
+  // Meta data that should be unconditionally saved is set here.
+  addAdditionalMetaBoolEntry("websockets", (options->connection_flags & WEBSOCKET_SUPPORT));
+  addAdditionalMetaBoolEntry("tls", (options->connection_flags & TLS_SUPPORT));
   return useropt;
 }
 
@@ -593,4 +596,39 @@ int is_buffer_clogged(int nextseqtosend, int lastunackedseq) {
     recclog = 1;
   }
   return recclog;
+}
+
+/**
+ * Adds data to the `meta` global variable.  All meta entries are key: value
+ * pairs mapping strings to strings.
+ * @param key the key for the entry
+ * @param value the value of the entry
+ */
+void addAdditionalMetaEntry(char* key, char* value) {
+  struct metaentry * new_entry;
+  new_entry = (struct metaentry *)calloc(1, sizeof(struct metaentry));
+  if (meta.additional) {
+    new_entry->next = meta.additional;
+  } else {
+    new_entry->next = NULL;
+  }
+  snprintf(new_entry->key, sizeof(new_entry->key) - 1, "%s", key);
+  snprintf(new_entry->value, sizeof(new_entry->value) - 1, "%s", value);
+  meta.additional = new_entry;
+}
+
+/**
+ * A helper method to add a meta entry when the value is an int.
+ */
+void addAdditionalMetaIntEntry(char* key, int value) {
+  char tmpbuff[256] = {0};
+  snprintf(tmpbuff, sizeof(tmpbuff) - 1, "%d", value);
+  addAdditionalMetaEntry(key, tmpbuff);
+}
+
+/**
+ * A helper method to add a meta entry when the value is a bool.
+ */
+void addAdditionalMetaBoolEntry(char* key, int value) {
+  addAdditionalMetaEntry(key, value ? "true" : "false");
 }

--- a/src/testoptions.h
+++ b/src/testoptions.h
@@ -94,4 +94,8 @@ void setCwndlimit(tcp_stat_connection connarg, tcp_stat_group* grouparg,
 int is_buffer_clogged(int nextseqtosend, int lastunackedseq);
 void stop_packet_trace(int *monpipe_arr);
 
+void addAdditionalMetaEntry(char* key, char* value);
+void addAdditionalMetaIntEntry(char* key, int value);
+void addAdditionalMetaBoolEntry(char* key, int value);
+
 #endif  // SRC_TESTOPTIONS_H_


### PR DESCRIPTION
The meta values for tls and websockets are now saved whether or not the client actually runs the meta test.

Required a little more code movement than I thought it would, and it gave me a chance to fix an egregiously bad implementation of a linked list as part of moving code around.