### PR TITLE
Extend c2s server read loop by 1 second.

### DIFF
--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -502,7 +502,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
 
   activeStreams = connections_to_fd_set(c2s_conns, streamsNum, &rfd, &max_fd);
 
-  while (activeStreams > 0 && (secs() - start_time) < testDuration) {
+  while (activeStreams > 0 && (secs() - start_time - 1) < testDuration) {
     // POSIX says "Upon successful completion, the select() function may
     // modify the object pointed to by the timeout argument."
     // Therefore sel_tv is undefined afterwards and we must set it every time.


### PR DESCRIPTION
This change addresses a regression observed for web100clt during the c2s test.
In particular, before this change, web100clt can block while writing after the
c2s server stopped reading. This causes the rest of the test to fail.

The server implementation in NDT 3.7.0 attempted to read longer than the client
wrote. The change in NDT 4.0.0 made the c2s read loop strictly conditional on
testDuration. This resulted in a race condition with the client.