### PR TITLE
Adds a second of reading after a c2s test

### DIFF
--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -122,7 +122,7 @@ const static int DRAIN_TIME = 1;
  * clients don't hang, but newer clients are not penalized for quitting after
  * 10 seconds, just like the spec says they can.
  *
- * TODO: Fix the clients to eliminate the need for this function.
+ * TODO: Fix web100clt to eliminate the need for this function.
  * TODO: Make this function happen in a separate thread (but not a forked
  *       subprocess due to SSL issues). That way old clients being dumb doesn't
  *       slow down new clients' tests.  Currently it wastes 1 second per test,
@@ -626,9 +626,9 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   *c2sspd = (8.0e-3 * bytes_read) / measured_test_duration;
 
   // As a kindness to old clients, drain their queues for a second or two.
-  // TODO: Fix client code to eliminate the need for this.  Clients that need
-  //       this line should be removed from their respective gene pools and
-  //       this code should be deleted.
+  // TODO: Fix web100clt code to eliminate the need for this.  In general,
+  //       clients that need this line should be removed from their respective
+  //       gene pools and this code should be deleted.
   drain_old_clients(c2s_conns, streamsNum, buff, sizeof(buff));
 
   // c->s throuput value calculated and assigned ! Release resources, conclude

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -627,7 +627,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
 
   // As a kindness to old clients, drain their queues for a second or two.
   // TODO: Fix client code to eliminate the need for this.  Clients that need
-  //       this line should be removed from their respective teme pools and
+  //       this line should be removed from their respective gene pools and
   //       this code should be deleted.
   drain_old_clients(c2s_conns, streamsNum, buff, sizeof(buff));
 

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -113,13 +113,13 @@ const static int DRAIN_TIME = 1;
 
 /**
  * web100clt currently (as of 2015-12-21) requires that its output queue be
- * drained at the end of the c2s test and crashes if it is not. We don't want
- * to break it, but that extra second or so should not be part of our measured
+ * drained at the end of the c2s test and hangs if it is not. We don't want to
+ * break it, but that extra second or so should not be part of our measured
  * transmitted data, because the spec says that it's a 10 second upload from
  * client to server, not a "10 seconds or a little bit more depending on when
  * the client starts counting" upload.  Therefore, here we read from the
  * sockets for just a little longer, but ignore the resulting data, so that old
- * clients don't crash, but newer clients are not penalized for quitting after
+ * clients don't hang, but newer clients are not penalized for quitting after
  * 10 seconds, just like the spec says they can.
  *
  * TODO: Fix the clients to eliminate the need for this function.


### PR DESCRIPTION
Adds a second of reading after a c2s test is done to allow old brittle clients to clear out their queues.