### PR TITLE
Removes 'Jitter' metric from HTML interface

### DIFF
--- a/HTML5-frontend/ndt-wrapper.js
+++ b/HTML5-frontend/ndt-wrapper.js
@@ -187,7 +187,6 @@ NDTWrapper.prototype.onfinish_cb = function (results) {
     this._ndt_vars = results;
     this._ndt_vars['ServerToClientSpeed'] = results['s2cRate'] / 1000;
     this._ndt_vars['ClientToServerSpeed'] = results['c2sRate'] / 1000;
-    this._ndt_vars['Jitter'] = results['MaxRTT'] - results['MinRTT'];
     this.build_diagnosis();
 };
 

--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -215,7 +215,6 @@ function setPhase(phase) {
       printDownloadSpeed();
       printUploadSpeed();
       $('#latency').html(printNumberValue(Math.round(averageRoundTrip())));
-      $('#jitter').html(printJitter(false));
       $('#test-details').html(testDetails());
       $('#test-advanced').append(testDiagnosis());
       $('#javaButton').attr('disabled', false);
@@ -435,11 +434,6 @@ function averageRoundTrip() {
   return parseFloat(testNDT().getNDTvar('avgrtt'));
 }
 
-function jitter() {
-  if (simulate) return 0;
-  return parseFloat(testNDT().getNDTvar('Jitter'));
-}
-
 function speedLimit() {
   if (simulate) return 0;
   return parseFloat(testNDT().get_PcBuffSpdLimit());
@@ -449,17 +443,6 @@ function printPacketLoss() {
   var packetLoss = parseFloat(testNDT().getNDTvar('loss'));
   packetLoss = (packetLoss*100).toFixed(2);
   return packetLoss;
-}
-
-function printJitter(boldValue) {
-  var retStr = '';
-  var jitterValue = jitter();
-  if (jitterValue >= 1000) {
-    retStr += (boldValue ? '<b>' : '') + printNumberValue(jitterValue/1000) + (boldValue ? '</b>' : '') + ' sec';
-  } else {
-    retStr += (boldValue ? '<b>' : '') + printNumberValue(jitterValue) + (boldValue ? '</b>' : '') + ' msec';
-  }
-  return retStr;
 }
 
 function getSpeedUnit(speedInKB) {
@@ -517,7 +500,6 @@ function testDetails() {
   d += 'TCP receive window: ' + readNDTvar('CurRwinRcvd').bold() + ' current, ' + readNDTvar('MaxRwinRcvd').bold() + ' maximum<br>';
   d += '<b>' + printNumberValue(printPacketLoss()) + '</b> % of packets lost during test<br>';
   d += 'Round trip time: ' + readNDTvar('MinRTT').bold() + ' msec (minimum), ' + readNDTvar('MaxRTT').bold() + ' msec (maximum), <b>' + printNumberValue(Math.round(averageRoundTrip())) + '</b> msec (average)<br>';
-  d += 'Jitter: ' + printNumberValue(printJitter(true)) + '<br>';
   d += readNDTvar('waitsec').bold() + ' seconds spend waiting following a timeout<br>';
   d += 'TCP time-out counter: ' + readNDTvar('CurRTO').bold() + '<br>';
   d += readNDTvar('SACKsRcvd').bold() + ' selective acknowledgement packets received<br>';

--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -117,7 +117,6 @@
 
         <div class="other">
           <p class="latency"><b>Network latency:</b> <span id="latency">0.0</span> msec round trip time</p>
-          <p class="jitter"><b>Jitter:</b> <span id="jitter">0.0 msec</span></p>
         </div>
 
       </div>


### PR DESCRIPTION
The HTML interface has been reporting a "Jitter" metric on the main NDT test results page.  This metric is the value of MaxRTT - MinRTT.  While in some technical sense this may be a measure of jitter by some definition, this is almost certainly not the same sense of the term jitter that the vast majority of people using the NDT test are going to want or understand.  This PR removes jitter from the results page, as well as just getting rid of the functions and variables that calculated and defined it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/48)

<!-- Reviewable:end -->
