### PR TITLE
Separation Frontend and Backend Functionality in NDT Client

### DIFF
--- a/HTML5-frontend/ndt-library.js
+++ b/HTML5-frontend/ndt-library.js
@@ -43,12 +43,12 @@ function NDTLibjs() {
  * Operates on an instance of NDT to begin executing a test.
  * @return - {object} Returns the protocol or an error if no ndtServer set.
  */
-NDTLibjs.prototype.startTest_ = function () {
+NDTLibjs.prototype.startTest = function () {
   try {
     if (this.ndtServer) {
       this.use_websocket_client_ = this.checkInstalledPlugins_();
       this.websocket_client_ = this.createBackend_(this.use_websocket_client_);
-      this.testNDT_().run_test(this.ndtServer);
+      this.testNDT().run_test(this.ndtServer);
       return this.websocket_client_;
     }
     throw new Error("No MLab Server could be found.");
@@ -142,74 +142,74 @@ NDTLibjs.prototype.getServer_ = function () {
  * Gets the test status of the current NDT test
  * @return - {string} status of current test
  */
-NDTLibjs.prototype.testStatus = function() {
+NDTLibjs.prototype.testStatus = function () {
   return this.testNDT().get_status();
-}
+};
 
 /**
  * Gets error messages of the current NDT test
  * @return - {string} error message if occurred
  */
-NDTLibjs.prototype.testError = function() {
+NDTLibjs.prototype.testError = function () {
   return this.testNDT().get_errmsg();
-}
+};
 
 /**
  * Gets hostname of server running test
  * @return - {string} hostname of server
  */
-NDTLibjs.prototype.remoteServer = function() {
-  if (this.simulate) return '0.0.0.0';
+NDTLibjs.prototype.remoteServer = function () {
+  if (this.simulate) { return '0.0.0.0'; }
   return this.testNDT().get_host();
-}
+};
 
 /**
  * Gets the Upload speed of the current NDT test
  * @return - {float} speed of uploading to server
  */
-NDTLibjs.prototype.uploadSpeed = function(raw) {
+NDTLibjs.prototype.uploadSpeed = function (raw) {
   var speed;
 
-  if (this.simulate) return 0;
+  if (this.simulate) { return 0; }
   speed = this.testNDT().getNDTvar('ClientToServerSpeed');
   return raw ? speed : parseFloat(speed);
-}
+};
 
 /**
  * Gets the Download speed of the current NDT test
  * @return - {float} speed of downloading from server
  */
-NDTLibjs.prototype.downloadSpeed = function() {
-  if (this.simulate) return 0;
+NDTLibjs.prototype.downloadSpeed = function () {
+  if (this.simulate) { return 0; }
   return parseFloat(this.testNDT().getNDTvar('ServerToClientSpeed'));
-}
+};
 
 /**
  * Gets the Average round trip speed of the current NDT test
  * @return - {float} speed of round trip
  */
-NDTLibjs.prototype.averageRoundTrip = function() {
-  if (this.simulate) return 0;
+NDTLibjs.prototype.averageRoundTrip = function () {
+  if (this.simulate) { return 0; }
   return parseFloat(this.testNDT().getNDTvar('avgrtt'));
-}
+};
 
 /**
  * Gets the Jitter value of the current NDT test
  * @return - {float} jitter value
  */
-NDTLibjs.prototype.jitter = function() {
-  if (this.simulate) return 0;
+NDTLibjs.prototype.jitter = function () {
+  if (this.simulate) { return 0; }
   return parseFloat(this.testNDT().getNDTvar('Jitter'));
-}
+};
 
 /**
  * Gets the current top speed of tests
  * @return - {float} speed limit value during current test
  */
-NDTLibjs.prototype.speedLimit = function() {
-  if (this.simulate) return 0;
+NDTLibjs.prototype.speedLimit = function () {
+  if (this.simulate) { return 0; }
   return parseFloat(this.testNDT().get_PcBuffSpdLimit());
-}
+};
 
 // instantiate NDT object
 var NDT = {};


### PR DESCRIPTION
This PR is the first step at separating out the Frontend and Backend functionality that exists today in the NDT client as discussed in https://github.com/m-lab/m-lab.github.io/issues/102 on the MLab website.  The idea is to ease how an implementer might include an NDT js library onto their website and by including only the necessary js, an implementer could create their own frontend using the NDT js library.  

As the current implementation would require a website to include [five different scripts](https://github.com/m-lab/m-lab.github.io/pull/76/files#diff-56ff23ff6448049981daee3c0344f9cdR22), this PR starts to address that breaking up the [script.js](https://github.com/m-lab/ndt/blob/master/HTML5-frontend/script.js) file into frontend and backend functionality.  This removes the dependency for an NDT js library to need jQuery, the gauges.min.js library, or the script.js file.  Those files would **ONLY** be needed if a user wanted the NDT frontend that exists on the site today, but not if it was creating a custom frontend.

Other implementation notes:
- If we can determine how best to combine the 3 backend scripts, and implementer could simply include      1 js script and then write their own frontend using the library of existing methods against the newly created `NDT` object.  For example, to trigger the start of a test, a developer can now simply write `NDT.startTest()` in their own frontend code.  Similarly, to get the status of a test, a developer can now simply write `NDT.testStatus()`, and etc.
- made one minor tweak in the ndt-browser-client.js file as that function is called in multiple places and since self is referring to last created object doesn't always work.
- added more documentation in both the code that remained in the script.js file

Items this PR does **NOT** address:
- [ ] Combining the ndt-wrapper.js, ndt-browser-client.js, and newly created ndt-library.js into one concatenated/min file.  This enhancement would be a new PR, but we need to decide if it is best to
      1. create a build script to do this - 
          I'd lean towards doing this, however, not sure if we do this, where does this library build and get deployed?  Additionally, if other repos are using git submodules, are those sites expected to build this as well or just link to a place where the js is deployed?  Should the build script be included in the parent repo that includes this code via submodule?
      2. manually concatenate these js files into one file - 
          Simpler solution, however, not as clean codebase obviously.

- [ ] Combining the jquery, gauges.min.js, and script.js files into one file or separating these into it's own "frontend" repo.  Not sure if this is even desired, but something to think about optimally implementing.

- [ ] Updates to the "widget.html" file.  This [file](https://github.com/m-lab/ndt/blob/master/HTML5-frontend/widget.html) seems pretty different than what is on the [mlab website](https://github.com/m-lab/m-lab.github.io/blob/master/_layouts/ndt-test.html) and not sure if there is one that is right or wrong so not sure what would be best to proceed on this.  For example, should we just update this widget to point to the newly separated js?  Also, I think this can be fixed once it is decided on how scripts may be concat/min above.

Other Enhancements that could be done here:
- [ ] Some documentation clearly identifying the methods and tools available with the NDT js library so implementers know how to use it.  Maybe this can be generated with jsDocs given scripts are following proper formats.  I imagine additional detail may be needed here though.  Also, need to figure out where this should live?  Within this repo or external?
- [ ] Enhance the "monitoring" of a test so it is easier for implementers to get test results.  A couple areas in the script.js still have un-obvious chaining that probably wouldn't be easy for implementers.  I can tweak this a bit more to get this to be a little friendlier, but wanted to get a PR going to start to ensure we are on the right track with the approach.
- [ ] I wonder if some of the "monitoring" sections in the script.js could also be re-worked to utilize templates/binding instead of hardcoding html in there.
- [ ] Is there a use case for a user passing in a specific server?  If so, then maybe we could make that more dynamic as well and over-ride what is being returned in the ajax call to get the backend server to run tests against.
- [ ] Introduce unit test framework and unit tests for this library

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/49)
<!-- Reviewable:end -->
