### PR TITLE
Three small bugfixes

### DIFF
--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -215,8 +215,9 @@ void packet_trace_emergency_shutdown(int *mon_pipe) {
  * @returns true if the fd is readable, false otherwise
  */
 int wait_for_readable_fd(int fd) {
-  fd_set rfd = {0};
+  fd_set rfd;
   struct timeval sel_tv = {0};
+  FD_ZERO(&rfd);
   FD_SET(fd, &rfd);
   sel_tv.tv_sec = 1;  // Wait for up to 1 second
   return (1 == select(fd + 1, &rfd, NULL, NULL, &sel_tv));


### PR DESCRIPTION
Three small bugfixes, one of which was causing real issues for MLab servers in developing nations.

 * A one-line compiler warning fix for test_c2s.
 * Fixing watchdog timer issues in web100srv.  (The server bug)
 * Making end-to-end unit tests less flaky by no longer just assuming that every port in the range [1024, 31024) is fine for the server to take as its own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/52)
<!-- Reviewable:end -->
