### PR TITLE
Update HTML-frontend Makefile to reference new version of jquery.

### DIFF
--- a/HTML5-frontend/Makefile.am
+++ b/HTML5-frontend/Makefile.am
@@ -18,7 +18,7 @@ TEMPDIRS = dist
 
 ndtdir = $(prefix)/ndt
 
-nobase_ndt_DATA = jquery-1.4.4.min.js ie.css style.css gauge.min.js widget.html \
+nobase_ndt_DATA = jquery-1.12.1.min.js ie.css style.css gauge.min.js widget.html \
 	   images/mlab-logo.png images/mlab-logo-small.png script.js \
            fonts/digital-7-mono.ttf fonts/League_Gothic.otf \
            fonts/League_Gothic.eot embed.html ndt-wrapper.js ndt-wrapper-ww.js ndt-browser-client.js


### PR DESCRIPTION
Building NDT fails in HTML-frontend/ because the Makefile was referencing an older version of the jQuery library which no longer exists in that directory.  Updates the Makefile to reference the version currently installed there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/53)
<!-- Reviewable:end -->
