### PR TITLE
Separating Frontend and Backend Functionality in NDT HTML5 Client - Part 1

### DIFF
--- a/HTML5-frontend/ndt-browser-client.js
+++ b/HTML5-frontend/ndt-browser-client.js
@@ -69,7 +69,7 @@ function NDTjs(server, serverPort, serverProtocol, serverPath, callbacks,
 /**
  * Provide feedback to the console or the DOM.
  * @param {string} logMessage Message to pass to output mechanism.
- * @param {!boolean=} debugging Optional (may be undefined) Determines whether 
+ * @param {!boolean=} debugging Optional (may be undefined) Determines whether
  *  to output messages or to operate silently.
  */
 NDTjs.prototype.logger = function (logMessage, debugging) {
@@ -84,6 +84,7 @@ NDTjs.prototype.logger = function (logMessage, debugging) {
  * @returns {boolean} Browser supports necessary functions for test client.
  */
 NDTjs.prototype.checkBrowserSupport = function () {
+  if (typeof window != "undefined") self = window;
   if (self.WebSocket === undefined && self.MozWebSocket === undefined) {
     throw this.UnsupportedBrowser('No Websockets');
   }
@@ -118,7 +119,7 @@ NDTjs.prototype.makeLoginMessage = function (desiredTests) {
 /**
  * A generic message creation system for NDT.
  * (messageType, message body length [2], message body)
- * @params {number} messageType The type of message according to NDT's 
+ * @params {number} messageType The type of message according to NDT's
  *  specification.
  * @params {string} messageContent The message body.
  * @returns {array} An array of bytes suitable for sending on a binary
@@ -208,7 +209,7 @@ NDTjs.prototype.createWebsocket = function (serverProtocol, serverAddress,
 /**
  * NDT's Client-to-Server (C2S) Upload Test
  * Serves as a closure that will process all messages for the C2S NDT test.
- * @returns {boolean} The test is complete and the closure should no longer 
+ * @returns {boolean} The test is complete and the closure should no longer
  *    be called.
  */
 NDTjs.prototype.ndtC2sTest = function () {
@@ -252,7 +253,7 @@ NDTjs.prototype.ndtC2sTest = function () {
   };
 
   /**
-   * The closure that processes messages on the control socket for the 
+   * The closure that processes messages on the control socket for the
    * C2S test.
    */
   return function (messageType, messageContent) {
@@ -296,7 +297,7 @@ NDTjs.prototype.ndtC2sTest = function () {
  * NDT's Server-to-Client (S2C) Download Test
  * Serves as a closure that will process all messages for the S2C NDT test.
  * @param {Websocket} ndtSocket A websocket connection to the NDT server.
- * @returns {boolean} The test is complete and the closure should no longer 
+ * @returns {boolean} The test is complete and the closure should no longer
  *    be called.
  */
 NDTjs.prototype.ndtS2cTest = function (ndtSocket) {
@@ -307,7 +308,7 @@ NDTjs.prototype.ndtS2cTest = function (ndtSocket) {
     that = this;
 
   /**
-  * The closure that processes messages on the control socket for the 
+  * The closure that processes messages on the control socket for the
   * C2S test.
   */
   return function (messageType, messageContent) {
@@ -396,7 +397,7 @@ NDTjs.prototype.ndtS2cTest = function (ndtSocket) {
 
 /**
  * NDT's META (S2C) Download Test
- * Serves as a closure that will process all messages for the META NDT test, 
+ * Serves as a closure that will process all messages for the META NDT test,
  *    which provides additional data to the NDT results.
  * @param {Websocket} ndtSocket A websocket connection to the NDT server.
  * @returns {boolean} The test is complete and the closure should no longer

--- a/HTML5-frontend/ndt-library.js
+++ b/HTML5-frontend/ndt-library.js
@@ -1,0 +1,234 @@
+/**
+ * @fileoverview This javascript code includes an NDT object that contains the
+ * methods that a customized front end implemetation of the NDT test could
+ * utilize.  The NDT object is self invoked when the library is included on a
+ * page, however, the frontend can customize certain properties when the
+ * interaction is initialized with the startTest method.
+ *
+ * Dependencies: ndt-wrapper.js, ndt-browser-client.js
+ */
+
+
+/**
+ * Immediately invoked function expression that creates NDT library object
+ */
+(function (window) {
+  'use strict';
+
+  /** @constructor */
+  function NDTLibjs() {
+
+    // Look up a suitable NDT server using mlab-ns. The ndtServer property is
+    //  used by the backend javascript to determine which server to test
+    //  against.
+    this.getServer();
+
+    // Initializes simulate property to false.  Can be changed upon starting a
+    // test in the testServer method
+    this.simulate = false;
+
+    // STATUS VARIABLES
+    this.use_websocket_client = false;
+    this.websocket_client = null;
+
+  }
+
+  /**
+   * Operates on an instance of NDT to begin executing a test.
+   * @param - none
+   * @return - {string} True if client is using websockets, False if error
+   * occurred during finding backend server, or applet container element fall
+   * back to Java applet.
+   */
+  NDTLibjs.prototype.startTest = function() {
+    if (NDT.ndtServer) {
+      this.checkInstalledPlugins();
+      var clientProtocol = this.createBackend();
+      this.testNDT().run_test(this.ndtServer);
+    } else {
+      // in case AJAX call fails or is taking longer
+      this.getServer();
+      return false;
+    }
+    return clientProtocol;
+  }
+
+  /**
+   * Operates on an instance of NDT to determine if the browser supports use of
+   * websockets.  If not, will attempt to use Java if available.
+   */
+  NDTLibjs.prototype.checkInstalledPlugins = function() {
+    var hasJava = false;
+    var hasWebsockets = false;
+
+    hasJava = true;
+    if (typeof deployJava !== 'undefined') {
+      if (deployJava.getJREs() == '') {
+        hasJava = false;
+      }
+    }
+    hasWebsockets = false;
+    try {
+      var ndt_js = new NDTjs();
+      if (ndt_js.checkBrowserSupport()) {
+        hasWebsockets = true;
+      }
+    } catch(e) {
+      hasWebsockets = false;
+    }
+
+    if (hasWebsockets) {
+      this.use_websocket_client = true;
+
+    }
+    else if (hasJava) {
+      this.use_websocket_client = false;
+
+    }
+  }
+
+  /**
+   * Creates the backend for the NDT object.  Tries to create websocket backend
+   * if supported, falls back to java applet if websocket not available
+   * @return - {obj} If Java is to be used returns Java applet information,
+   *     otherwise returns false
+   */
+  NDTLibjs.prototype.createBackend = function() {
+    if (this.use_websocket_client) {
+      this.websocket_client = new NDTWrapper(this.ndtServer);
+      return true;
+    }
+    else {
+      var app = document.createElement('applet');
+      app.id = 'NDT';
+      app.name = 'NDT';
+      app.archive = 'Tcpbw100.jar';
+      app.code = 'edu.internet2.ndt.Tcpbw100.class';
+      app.width = '600';
+      app.height = '10';
+
+      return app;
+    }
+  }
+
+  /**
+   * Determines where to run the tests.  If against the websocket or Java
+   * applet
+   * @return - {obj} websocket client or java applet element id
+   */
+  NDTLibjs.prototype.testNDT = function() {
+    if (this.websocket_client) {
+      return this.websocket_client;
+    }
+
+    return $('#NDT');
+  }
+
+  /**
+   * AJAX call to determine what server to run tests against.
+   * @return - none, sets object property for server
+   */
+  NDTLibjs.prototype.getServer = function () {
+    var mlabNsService = 'https:' == location.protocol ? 'ndt_ssl' : 'ndt';
+    var mlabNsUrl = 'https://mlab-ns.appspot.com/';
+    self = this;
+
+    var NDTAjax = new XMLHttpRequest();
+    NDTAjax.open('GET', mlabNsUrl + mlabNsService + '?format=json', true);
+    NDTAjax.onreadystatechange = function () {
+      // completed and successful
+      if (NDTAjax.readyState == 4 && NDTAjax.status == 200) {
+        var resp = JSON.parse(NDTAjax.responseText);
+        console.log('Using NDT server: ' + resp.fqdn);
+        self.ndtServer = resp.fqdn;
+      }
+      // failed
+      else if (NDTAjax.readyState == 4 && NDTAjax.status != 200) {
+        console.log('mlab-ns lookup failed: ' + NDTAjax.status);
+        self.ndtServer = false;
+      }
+    };
+    NDTAjax.send();
+  };
+
+
+  // Monitoring Test Functions
+
+  /**
+   * Gets the test status of the current NDT test
+   * @return - {sting} status of current test
+   */
+  NDTLibjs.prototype.testStatus = function() {
+    return this.testNDT().get_status();
+  }
+
+  /**
+   * Gets error messages of the current NDT test
+   * @return - {sting} error message if occurred
+   */
+  NDTLibjs.prototype.testError = function() {
+    return this.testNDT().get_errmsg();
+  }
+
+  /**
+   * Gets hostname of server running test
+   * @return - {string} hostname of server
+   */
+  NDTLibjs.prototype.remoteServer = function() {
+    if (this.simulate) return '0.0.0.0';
+    return this.testNDT().get_host();
+  }
+
+  /**
+   * Gets the Upload speed of the current NDT test
+   * @return - {float} speed of uploading to server
+   */
+  NDTLibjs.prototype.uploadSpeed = function(raw) {
+    if (this.simulate) return 0;
+    var speed = this.testNDT().getNDTvar('ClientToServerSpeed');
+    return raw ? speed : parseFloat(speed);
+  }
+
+  /**
+   * Gets the Download speed of the current NDT test
+   * @return - {float} speed of downloading from server
+   */
+  NDTLibjs.prototype.downloadSpeed = function() {
+    if (this.simulate) return 0;
+    return parseFloat(this.testNDT().getNDTvar('ServerToClientSpeed'));
+  }
+
+  /**
+   * Gets the Average round trip speed of the current NDT test
+   * @return - {float} speed of round trip
+   */
+  NDTLibjs.prototype.averageRoundTrip = function() {
+    if (this.simulate) return 0;
+    return parseFloat(this.testNDT().getNDTvar('avgrtt'));
+  }
+
+  /**
+   * Gets the Jitter value of the current NDT test
+   * @return - {float} jitter value
+   */
+  NDTLibjs.prototype.jitter = function() {
+    if (this.simulate) return 0;
+    return parseFloat(this.testNDT().getNDTvar('Jitter'));
+  }
+
+  /**
+   * Gets the current top speed of tests
+   * @return - {float} speed limit value during current test
+   */
+  NDTLibjs.prototype.speedLimit = function() {
+    if (this.simulate) return 0;
+    return parseFloat(this.testNDT().get_PcBuffSpdLimit());
+  }
+
+
+  // if not already created, instantiate object just in case
+  if (typeof(NDT) === 'undefined') {
+    window.NDT = new NDTLibjs();
+  }
+
+})(window);

--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -1,18 +1,19 @@
+/**
+ * @fileoverview Reflects the functionality that is used on the NDT frontend on
+ * the mlab website.
+ *
+ * Dependencies: ndt-client-wrapper.js ndt-wrapper.js, ndt-browser-client.js,
+ * gauge.min.js, jQuery
+ */
+
+'use strict';
+
 if (typeof simulate === 'undefined') {
   var simulate = false;
 }
 
 $(function(){
   jQuery.fx.interval = 50;
-  $('#welcome').show();
-  $('#copyButton').click(
-    function(){
-      copyToClipboardMsg($('#copyTarget'), 'copy-msg');
-    });
-  $('.embed').click(
-    function(){
-     $('#copy-code').slideToggle('slow');
-    });
   if (simulate) {
     setTimeout(initializeTest, 1000);
     return;
@@ -46,11 +47,16 @@ var gaugeMaxValue = 1000;
 
 // PRIMARY METHODS
 
+/**
+ * Sets up the front end to run NDT client by initializing the spped gauges,
+ * setting the initial phase to "welcome", and adding event listeners for
+ * result page tabs/buttons
+ */
 function initializeTest() {
   // Initialize gauges
   initializeGauges();
 
-  // Initialize start buttons
+  // Initialize start button
   $('.start.button').click(startTest);
 
   // Results view selector
@@ -60,11 +66,16 @@ function initializeTest() {
 
   $('body').removeClass('initializing');
   $('body').addClass('ready');
-  //return showPage('results');
   setPhase(PHASE_WELCOME);
 }
 
+/**
+ * Function that starts the NDT test executing.  Depending on what is returned
+ * from NDT library, accounts for using a websocket or Java Applet type of test
+ * @param {event} - event that triggered function
+ */
 function startTest(evt) {
+  //stop button click behavior and start NDT test
   evt.stopPropagation();
   evt.preventDefault();
   if (simulate) {
@@ -87,6 +98,10 @@ function startTest(evt) {
   monitorTest();
 }
 
+/**
+ * Function used for testing purposes to simulate an NDT test without actually
+ * interacting with the backend data.
+ */
 function simulateTest() {
   setPhase(PHASE_RESULTS);
   return;
@@ -96,16 +111,14 @@ function simulateTest() {
   setTimeout(function(){ setPhase(PHASE_RESULTS) }, 6000);
 }
 
+/**
+ * Contains functionality that will handle errors as well as update the front
+ * end with speed information and change of status phases.
+ * @return {boolean} - optional, if test is completed or errored out.
+ */
 function monitorTest() {
   var message = NDT.testError();
   var currentStatus = NDT.testStatus();
-
-  /*
-  var currentStatus = testStatus();
-  debug(currentStatus);
-  var diagnosis = testDiagnosis();
-  debug(diagnosis);
-  */
 
   if (message.match(/not run/) && currentPhase != PHASE_LOADING) {
     setPhase(PHASE_WELCOME);
@@ -138,8 +151,6 @@ function monitorTest() {
 
   setTimeout(monitorTest, 1000);
 }
-
-
 
 // PHASES
 
@@ -235,9 +246,13 @@ function setPhase(phase) {
   currentPhase = phase;
 }
 
-
 // PAGES
-
+/**
+ * Shows or hides certain container elements on the front end depending on the
+ * phase the test is currently in.
+ * @param {string} id of page to be shown
+ * @param {string} optional, callback method
+ */
 function showPage(page, callback) {
   debug('Show page: ' + page);
   if (page == currentPage) {
@@ -256,7 +271,6 @@ function showPage(page, callback) {
   currentPage = page;
 }
 
-
 // RESULTS
 
 function showResultsSummary() {
@@ -271,6 +285,10 @@ function showResultsAdvanced() {
   showResultsPage('advanced');
 }
 
+/**
+ * Shows or hides certain tabs on results screen
+ * @param {string} id of tab
+ */
 function showResultsPage(page) {
   debug('Results: show ' + page);
   var pages = ['summary', 'details', 'advanced'];
@@ -279,9 +297,12 @@ function showResultsPage(page) {
   }
 }
 
-
 // GAUGE
 
+/**
+ * Sets up gauges used in client to display upload/download speeds as results
+ * are coming in.
+ */
 function initializeGauges() {
   var gaugeValues = [];
 
@@ -356,6 +377,9 @@ function updateGaugeValue() {
 
 // TESTING JAVA/WEBSOCKET CLIENT
 
+/**
+ * Parses, formats, and displays final diagnostic information for NDT test
+ */
 function testDiagnosis() {
   var div = document.createElement('div');
 
@@ -453,6 +477,10 @@ function printNumberValue(value) {
   return isNaN(value) ? '-' : value;
 }
 
+/**
+ * Parses, formats, and displays final summary of diagnostic information for
+ * NDT test
+ */
 function testDetails() {
   if (simulate) return 'Test details';
 
@@ -532,8 +560,11 @@ function isPluginLoaded() {
   }
 }
 
-// Attempts to determine the absolute path of a script, minus the name of the
-// script itself.
+/**
+ * Attempts to determine the absolute path of a script, minus the name of the
+ * script itself.
+ * @return {string} path of script
+ */
 function getScriptPath() {
   var scripts = document.getElementsByTagName('SCRIPT');
   var fileRegex = new RegExp('\/ndt-wrapper\.js$');

--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -6,6 +6,9 @@
  * gauge.min.js, jQuery
  */
 
+/*jslint bitwise: true, browser: true, indent: 2, nomen: true */
+/*global $, jQuery, Gauge, NDT, simulate*/
+
 'use strict';
 
 if (typeof simulate === 'undefined') {
@@ -75,6 +78,8 @@ function initializeTest() {
  * @param {event} - event that triggered function
  */
 function startTest(evt) {
+  var clientProtocol;
+
   //stop button click behavior and start NDT test
   evt.stopPropagation();
   evt.preventDefault();
@@ -82,7 +87,7 @@ function startTest(evt) {
     return simulateTest();
   } else {
     $('#backendContainer').empty();
-    var clientProtocol = NDT.startTest();
+    clientProtocol = NDT.startTest();
     if (clientProtocol == false) {
       $('#warning-plugin').show();
       return false;
@@ -482,11 +487,12 @@ function printNumberValue(value) {
  * NDT test
  */
 function testDetails() {
+  var d = '',
+    errorMsg;
+
   if (simulate) return 'Test details';
 
-  var d = '';
-
-  var errorMsg = NDT.testError();
+  errorMsg = NDT.testError();
   if (errorMsg.match(/failed/)) {
     d += 'Error occured while performing test: <br>'.bold();
     if (errorMsg.match(/#2048/)) {

--- a/HTML5-frontend/style.css
+++ b/HTML5-frontend/style.css
@@ -39,6 +39,7 @@ a img {
 #warning-plugin, #warning-websocket {
   color: red;
   margin: 5px;
+  display: none;
 }
 .page {
   width: 640px;

--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -10,6 +10,7 @@
     <script type="text/javascript" src="jquery-1.12.1.min.js"></script>
     <script type="text/javascript" src="gauge.min.js"></script>
     <script type="text/javascript" src="script.js"></script>
+    <script type="text/javascript" src="ndt-library.js"></script>
     <script type="text/javascript" src="ndt-browser-client.js"></script>
     <script type="text/javascript" src="ndt-wrapper.js"></script>
     <script type="text/javascript" src="http://www.java.com/js/deployJava.js"></script>


### PR DESCRIPTION
Per feedback contained in #49 this PR splits the changes in that PR into a more manageable PR.  This first PR contains and only contains the changes needed to separate the backend functionality from the `script.js` file into an `ndt-library.js` file.  When moving that functionality to the `ndt-library.js` file, it needs to be removed from the `script.js` file and then minimal changes to make sure the application still works.

The idea is to ease how an implementer might include an NDT js library onto their website and by including only the necessary js, an implementer could create their own frontend using the NDT js library.  

As the current implementation would require a website to include [five different scripts](https://github.com/m-lab/m-lab.github.io/pull/76/files#diff-56ff23ff6448049981daee3c0344f9cdR22), this PR starts to address that breaking up the [script.js](https://github.com/m-lab/ndt/blob/master/HTML5-frontend/script.js) file into frontend and backend functionality.  This removes the dependency for an NDT js library to need jQuery, the gauges.min.js library, or the script.js file.  Those files would **ONLY** be needed if a user wanted the NDT frontend that exists on the site today, but not if it was creating a custom frontend.

1 small change was made to the css and `ndt-browser-client.js`  files in order to make the application still function properly.

Finally, also added the ndt-library.js include into the widget.html.

Once this PR and part 2 #55 is merged, #49 can be closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/54)
<!-- Reviewable:end -->
