### PR TITLE
Watchdog timer, error path bugfixes, and a logging cleanup.

### DIFF
--- a/src/web100-pcap.c
+++ b/src/web100-pcap.c
@@ -899,7 +899,7 @@ void init_pkttrace(I2Addr srcAddr, struct sockaddr_storage sock_addr[], int sock
 
   /*  device = pcap_lookupdev(errbuf); */
   if (device == NULL) {
-    fprintf(stderr, "pcap_lookupdev failed\n", errbuf);
+    fprintf(stderr, "pcap_lookupdev failed\n");
   }
 
   log_println(1, "Opening network interface '%s' for packet-pair timing",

--- a/src/web100-pcap.c
+++ b/src/web100-pcap.c
@@ -899,7 +899,7 @@ void init_pkttrace(I2Addr srcAddr, struct sockaddr_storage sock_addr[], int sock
 
   /*  device = pcap_lookupdev(errbuf); */
   if (device == NULL) {
-    fprintf(stderr, "pcap_lookupdev failed: %s\n", errbuf);
+    fprintf(stderr, "pcap_lookupdev failed\n", errbuf);
   }
 
   log_println(1, "Opening network interface '%s' for packet-pair timing",


### PR DESCRIPTION
Adds the watchdog timer as the very first thing, and eliminates the "return"

from the error paths which is never the right thing and is potentially
disastrous.

Also, eliminates a string from a log line which frequently ended up being a
pointer to memory that did not contain a string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/65)
<!-- Reviewable:end -->
