### PR TITLE
Fix hanging child process problem.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -851,3 +851,24 @@ int setup_SSL_connection(Connection *conn, SSL_CTX *ctx) {
   } while (ssl_ret != 1);
   return 0;
 }
+
+/**
+ * Sets 5 minute read and write timeouts on the passed-in socket.  Calls exit()
+ * if setsockopt fails for any reason.
+ * @param sockfd the socket to modify
+ */
+void set_socket_timeout_or_die(int sockfd) {
+  struct timeval timeout;
+  timeout.tv_sec = 300;
+  timeout.tv_usec = 0;
+  if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout,
+                 sizeof(timeout)) < 0) {
+    log_println(1, "Could not setsockopt to set SO_RCVTIMEO");
+    exit(-1);
+  }
+  if (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout,
+                 sizeof(timeout)) < 0) {
+    log_println(1, "Could not setsockopt to set SO_SNDTIMEO");
+    exit(-1);
+  }
+}

--- a/src/network.h
+++ b/src/network.h
@@ -48,4 +48,6 @@ const char* ssl_error_str(int ssl_error);
 void shutdown_connection(Connection *conn);
 void close_connection(Connection *conn);
 
+void set_socket_timeout_or_die(int sockfd);
+
 #endif  // SRC_NETWORK_H_

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -452,6 +452,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
       }
       log_println(6, "accept(%d/%d) for %d completed", conn_index + 1,
                   streamsNum, testOptions->child0);
+      set_socket_timeout_or_die(c2s_conns[conn_index].socket);
 
       // log protocol validation indicating client accept
       protolog_procstatus(testOptions->child0, testids, CONNECT_TYPE,

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -516,6 +516,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         close_all_connections(c2s_conns, streamsNum);
         // Don't capture more than 14 seconds of packet traces:
         //   2 seconds of sleep + 10 seconds of test + 2 seconds of slop
+        // Causes a call to cleanup() if allowed to run for too long.
         alarm(testDuration + RACE_CONDITION_WAIT_TIME + 2);
         log_println(
             5,
@@ -572,7 +573,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   sleep(RACE_CONDITION_WAIT_TIME);
   // Reset alarm() again. This 10 sec test should finish before this signal is
   // generated, but sleep() can render existing alarm()s invalid, and alarm() is
-  // our watchdog timer.
+  // our watchdog timer. Watchdog code is in cleanup().
   alarm(30);
 
   // send empty TEST_START indicating start of the test

--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -315,6 +315,7 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
       xmitsfd[stream].socket = accept(testOptions->s2csockfd, (struct sockaddr *) &cli_addr[stream], &clilen);
       if (xmitsfd[stream].socket > 0) {
         log_println(6, "accept(%d/%d) for %d completed", stream, streamsNum, testOptions->child0);
+        set_socket_timeout_or_die(xmitsfd[stream].socket);
         if (testOptions->connection_flags & TLS_SUPPORT) {
           errno = setup_SSL_connection(&xmitsfd[stream], ctx);
           if (errno != 0) return -errno;
@@ -498,10 +499,6 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         log_println(6,
                     "S2C test - Test-start message failed for pid=%d",
                     s2c_childpid);
-      // ignore the alarm signal
-      memset(&new, 0, sizeof(new));
-      new.sa_handler = catch_s2c_alrm;
-      sigaction(SIGALRM, &new, &old);
 
       // capture current values (i.e take snap shot) of web_100 variables
       // Write snap logs if option is enabled. update meta log to point to
@@ -597,8 +594,6 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         }
       }
 
-      /* alarm(10); */
-      sigaction(SIGALRM, &old, NULL);
       sndqueue = sndq_len(xmitsfd[0].socket);
 
       // finalize the midbox test ; disabling socket used for throughput test

--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -374,6 +374,7 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
           if ((s2c_childpid = fork()) == 0) {
             // Don't capture more than 12 seconds of packet traces:
             //   10 second test + 2 seconds of slop
+            // Causes a call to cleanup() if allowed to run for too long.
             alarm(testDuration + 2);
             close(testOptions->s2csockfd);
             for (i = 0; i < streamsNum; i++) {
@@ -522,7 +523,6 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
                               streams[i].conn, group);
         }
       }
-      /* alarm(20); */
       tmptime = secs();  // current time
       tx_duration = tmptime + testDuration;  // set timeout to test duration s in future
 
@@ -720,9 +720,6 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
 
       log_println(1, "%6.0f kbps inbound pid-%d", x2cspd, s2c_childpid);
     }
-    /* reset alarm() again, this 10 sec test should finish before this signal
-     * is generated.  */
-    /* alarm(30); */
     // Get web100 variables from snapshot taken earlier and send to client
     log_println(6, "S2C-Send web100 data vars to client pid=%d",
                 s2c_childpid);

--- a/src/test_sfw_srv.c
+++ b/src/test_sfw_srv.c
@@ -58,7 +58,7 @@ test_osfw_srv(void* vptr) {
   TestOptions* options = (TestOptions*)vptr;
   Connection conn = {-1, NULL};
 
-  // ignore the alarm signal
+  // Ignore the alarm signal so we can use alarm() as the test timer.
   memset(&new, 0, sizeof(new));
   new.sa_handler = catch_alrm;
   sigaction(SIGALRM, &new, &old);
@@ -72,7 +72,9 @@ test_osfw_srv(void* vptr) {
   }
 
   alarm(0);
+  // Reset the watchdog timer so that cleanup() can get called.
   sigaction(SIGALRM, &old, NULL);
+  alarm(30);
 
   // signal sleeping threads to wake up
   pthread_mutex_lock(&mainmutex);

--- a/src/testoptions.c
+++ b/src/testoptions.c
@@ -96,18 +96,6 @@ void findCwndPeaks(tcp_stat_agent* agent, CwndPeaks* peaks,
   prevCWNDval = CurCwnd;
 }
 
-/**
- * Print the appropriate message when the SIGALRM is caught.
- * @param signo The signal number (shuld be SIGALRM)
- */
-
-void catch_s2c_alrm(int signo) {
-  if (signo == SIGALRM) {
-    log_println(1, "SIGALRM was caught");
-    return;
-  }
-  log_println(0, "Unknown (%d) signal was caught", signo);
-}
 
 /**
  * Write the snap logs with fixed time intervals in a separate

--- a/src/testoptions.h
+++ b/src/testoptions.h
@@ -62,8 +62,6 @@ typedef struct snapArgs {
 int initialize_tests(Connection* ctl, TestOptions* testOptions,
                      char* test_suite, size_t test_suite_strlen);
 
-void catch_s2c_alrm(int signo);
-
 int test_sfw_srv(Connection* ctl, tcp_stat_agent* agent, TestOptions* options,
                  int conn_options);
 int test_meta_srv(Connection* ctl, tcp_stat_agent* agent,

--- a/src/web100-pcap.c
+++ b/src/web100-pcap.c
@@ -989,7 +989,7 @@ void init_pkttrace(I2Addr srcAddr, struct sockaddr_storage sock_addr[], int sock
     }
   }
 
-  /* kill process off if parent doesn't send a signal. */
+  /* kill process off via cleanup() if parent doesn't send a signal. */
   alarm(50 + expectedTestTime);
 
   if (pcap_loop(pd, cnt, printer, pcap_userdata) < 0) {

--- a/src/web100srv.c
+++ b/src/web100srv.c
@@ -334,6 +334,19 @@ void cleanup(int signo) {
       break;
 
     case SIGALRM:
+      // Receipt of SIGALRM means that the watchdog timer has gone off. We
+      // assume that this process is stuck in a hung state, and should
+      // therefore be killed. Given how TCP closes, it is inevitable that some
+      // tests will end up in a half-closed state but the server doesn't know
+      // (the FIN gets lost in flight, or the client disappears off the network
+      // because it was a cellphone that went underground, etc), so it is not
+      // true that every receipt of SIGALRM represents a bug.  Every receipt of
+      // SIGALRM does mean, however, that the process should be killed.
+      //
+      // Any code which installs an alternate handler of SIGALRM should be
+      // examined closely, as it could cause hung-forever child processes by
+      // preventing the watchdog from barking. Currently the only such code is
+      // in test_sfw.c
       switch (getCurrentTest()) {
         case TEST_MID:
           sigsafe_debug_log(6, signo, "Received SIGALRM signal [Middlebox test]");
@@ -771,7 +784,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
 
   // Run scheduled test. Log error code if necessary
   log_println(6, "Starting middlebox test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_mid(ctl, agent, testopt, conn_options, &s2c2spd)) != 0) {
     if (ret < 0)
       log_println(6, "Middlebox test failed with rc=%d", ret);
@@ -781,14 +794,14 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   }
 
   log_println(6, "Starting simple firewall test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_sfw_srv(ctl, agent, testopt, conn_options)) != 0) {
     if (ret < 0)
       log_println(6, "SFW test failed with rc=%d", ret);
   }
 
   log_println(6, "Starting c2s throughput test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_c2s(ctl, agent, testopt, conn_options, &c2sspd, set_buff,
                       window, autotune, device, &options, record_reverse,
                       count_vars, spds, &spd_index, ssl_context,
@@ -801,7 +814,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   }
 
   log_println(6, "Starting extended c2s throughput test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_c2s(ctl, agent, testopt, conn_options, &c2sspd,
                       set_buff, window, autotune, device, &options,
                       record_reverse, count_vars, spds, &spd_index,
@@ -814,7 +827,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   }
 
   log_println(6, "Starting s2c throughput test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_s2c(ctl, agent, testopt, conn_options, &s2cspd,
                       set_buff, window, autotune, device, &options, spds,
                       &spd_index, count_vars, &peaks, ssl_context, &s2c_ThroughputSnapshots, 0)) != 0) {
@@ -826,7 +839,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   }
 
   log_println(6, "Starting extended s2c throughput test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_s2c(ctl, agent, testopt, conn_options, &s2cspd,
                       set_buff, window, autotune, device, &options, spds,
                       &spd_index, count_vars, &peaks, ssl_context,
@@ -839,7 +852,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   }
 
   log_println(6, "Starting META test");
-  alarm(MAX_TEST_TIME);  // Kick the watchdog.
+  alarm(MAX_TEST_TIME);  // Kick the watchdog to prevent calls to cleanup.
   if ((ret = test_meta_srv(ctl, agent, testopt, conn_options, &options)) != 0) {
     if (ret != 0) {
       log_println(6, "META test failed with rc=%d", ret);
@@ -1368,14 +1381,15 @@ void process_parent_message(int parent_message, Connection *ctl,
     case SRV_QUEUE_SERVER_BUSY_60s:
       // The SRV_QUEUE_SERVER_BUSY_60s message is not emitted by any
       // codepaths in the server.  This message is likely obsolete.
-      // Set the watchdog alarm for 60 seconds, plus some slop.
+      // Set the watchdog alarm for 60 seconds, plus some slop, to prevent
+      // spurious calls to cleanup().
       alarm(120);
       break;
     default:
       // If the message was not one of the magic values, then it is a number
       // of minutes to wait until the test starts.  Set the watchdog alarm
       // for that many minutes, plus a little bit extra to avoid race
-      // conditions.
+      // conditions and prevent spurious calls to cleanup().
       alarm((parent_message + 1) * 60);
       break;
   }
@@ -1383,13 +1397,15 @@ void process_parent_message(int parent_message, Connection *ctl,
 
 /**
  * The code run by the child process. This function never returns, it only
- * calls exit().  It also has an alarm() timer which by default prevents any
- * client from living for more than 5 minutes.  The parent is in control, and
- * will send this child a signal when it gets to the head of the testing queue
- * (and will also send other status messages that are relayed by the client).
- * Only the child process can communicate to the client (OpenSSL connections
- * can only be used by one process), so we pass along any queueing messages we
- * get from the parent.
+ * calls exit().  It also has an alarm() timer which functions as a watchdog,
+ * and all communication sockets should have socket timeouts set.
+ *
+ * The parent process is in control, and will send this child a message on the
+ * parent_pipe when the child gets to the head of the testing queue (and will
+ * also send other status messages that are relayed by the child to the
+ * client).  Only the child process can communicate to the client (OpenSSL
+ * connections can only be used by one process), so the child should pass along
+ * any queueing messages received from the parent.
  */
 void child_process(int parent_pipe, SSL_CTX *ssl_context, int ctlsockfd) {
   FILE *fp;
@@ -1404,12 +1420,8 @@ void child_process(int parent_pipe, SSL_CTX *ssl_context, int ctlsockfd) {
   Connection ctl = {-1, NULL};
   ctl.socket = ctlsockfd;
 
-  // this is the child process, it handles the connection with the client and
-  // runs the actual tests.
-  // First, start the watchdog timer
-  alarm(300);
-  // Next, set send and receive timeouts on the socket
-  set_socket_timeout_or_die(ctl.socket);
+  // Start the watchdog timer. Receiving SIGALRM will call cleanup(SIGALRM).
+  alarm(alarm_time);
   // Set up the connection with the client (with optional SSL and websockets)
   if (ssl_context != NULL) {
     if (setup_SSL_connection(&ctl, ssl_context) != 0) {
@@ -1511,12 +1523,12 @@ void child_process(int parent_pipe, SSL_CTX *ssl_context, int ctlsockfd) {
     testopt.s2cextopt = TOPT_ENABLED;
     alarm_time += options.s2c_duration / 1000.0;
   }
-  // die in 120 seconds, but only if a test doesn't get started
+  // Die in 120 seconds via cleanup() but only if a test doesn't get started.
   alarm(alarm_time);
   // reset alarm() before every test
   log_println(6,
-              "setting master alarm() to 120 seconds, tests must start "
-              "(complete?) before this timer expires");
+              "setting master alarm() to %d seconds, tests must start "
+              "(complete?) before this timer expires", alarm_time);
 
   // run tests based on options
   if (strncmp(test_suite, "Invalid", 7) != 0) {
@@ -1637,7 +1649,8 @@ ndtchild *spawn_new_child(int listenfd, SSL_CTX *ssl_context) {
     // process.
 
     // The child should have a watchdog timer.  Start it first thing, so that
-    // no client can screw things up too badly.
+    // no client can livelock or deadlock for too long without causing a call
+    // to cleanup().
     alarm(300);
     cli_addr_len = sizeof(cli_addr);
   
@@ -1659,6 +1672,7 @@ ndtchild *spawn_new_child(int listenfd, SSL_CTX *ssl_context) {
       log_println(0, "Child terminating.");
       exit(-1);
     }
+    set_socket_timeout_or_die(ctlsockfd);
     // Copy connection data into global variables for the run_test() function.
     // Get meta test details copied into results.
     memcpy(&meta.c_addr, &cli_addr, cli_addr_len);

--- a/src/web100srv.c
+++ b/src/web100srv.c
@@ -343,7 +343,7 @@ void cleanup(int signo) {
       // true that every receipt of SIGALRM represents a bug.  Every receipt of
       // SIGALRM does mean, however, that the process should be killed.
       //
-      // Any code which installs an alternate handler of SIGALRM should be
+      // Any code that installs an alternate handler of SIGALRM should be
       // examined closely, as it could cause hung-forever child processes by
       // preventing the watchdog from barking. Currently the only such code is
       // in test_sfw.c
@@ -1902,6 +1902,12 @@ void perform_queue_maintenance(ndtchild **head) {
 
   // Walk the list of clients, sending the GO signal to clients that have
   // reached the front part of the queue.
+  //
+  // TODO: Keep track of how long each child has been running, and forcibly
+  // terminate any long-running children on the assumption that those children
+  // are deadlocked and will never exit on their own.  This would complement
+  // the child watchdog and provide another layer of defense against buggy test
+  // code.
   queue_position = 0;
   for (current = *head; current != NULL; current = current->next) {
     if (!current->running) {

--- a/src/web100srv.c
+++ b/src/web100srv.c
@@ -1403,11 +1403,13 @@ void child_process(int parent_pipe, SSL_CTX *ssl_context, int ctlsockfd) {
   tcp_stat_agent *agent;
   Connection ctl = {-1, NULL};
   ctl.socket = ctlsockfd;
+
   // this is the child process, it handles the connection with the client and
   // runs the actual tests.
   // First, start the watchdog timer
   alarm(300);
-
+  // Next, set send and receive timeouts on the socket
+  set_socket_timeout_or_die(ctl.socket);
   // Set up the connection with the client (with optional SSL and websockets)
   if (ssl_context != NULL) {
     if (setup_SSL_connection(&ctl, ssl_context) != 0) {


### PR DESCRIPTION
Adds 5 minute timeouts to the control socket, the s2c sockets, and the c2s
socket. Also removes the vestigial `alarm()` and SIGALRM handler in the s2c
test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/71)
<!-- Reviewable:end -->
