### PR TITLE
Removes Java option from HTML interface served by NDT sliver

### DIFF
--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -8,8 +8,9 @@ $(function(){
     setTimeout(initializeTest, 1000);
     return;
   }
-  checkInstalledPlugins();
-  initializeTest();
+  if ( checkInstalledPlugins() ) {
+    initializeTest();
+  }
 });
 
 // CONSTANTS
@@ -25,7 +26,7 @@ var PHASE_RESULTS   = 5;
 
 
 // STATUS VARIABLES
-var use_websocket_client = false;
+var use_websocket_client = true;
 var websocket_client = null;
 var currentPhase = PHASE_LOADING;
 var currentPage = 'welcome';
@@ -66,8 +67,10 @@ function startTest(evt) {
   evt.stopPropagation();
   evt.preventDefault();
   createBackend();
-  if (!isPluginLoaded()) {
-    return;
+  try {
+    testStatus();
+  } catch(e) {
+    return false;
   }
   showPage('test', resetGauges);
   $('#rttValue').html('');
@@ -563,16 +566,6 @@ function createBackend() {
   if (use_websocket_client) {
     websocket_client = new NDTWrapper(window.ndtServer);
   }
-  else {
-    var app = document.createElement('applet');
-    app.id = 'NDT';
-    app.name = 'NDT';
-    app.archive = 'Tcpbw100.jar';
-    app.code = 'edu.internet2.ndt.Tcpbw100.class';
-    app.width = '600';
-    app.height = '10';
-    $('#backendContainer').append(app);
-  }
 }
 
 // UTILITIES
@@ -583,18 +576,9 @@ function debug(message) {
   }
 }
 
-function isPluginLoaded() {
-  try {
-    testStatus();
-    return true;
-  } catch(e) {
-    return false;
-  }
-}
 
 function checkInstalledPlugins() {
   var hasWebsockets = false;
-
   try {
     var ndt_js = new NDTjs();
     if (ndt_js.checkBrowserSupport()) {
@@ -603,16 +587,13 @@ function checkInstalledPlugins() {
   } catch(e) {
     hasWebsockets = false;
   }
-
   if (hasWebsockets) {
     useWebsocketAsBackend();
   }
   else {
     $('#no-websocket').show()
-    $('#startButton').attr('pointer-events', 'none');
-    $('#startButton').css('background-color', '#4d4d4d');
-    $('#startButton').css('cursor', 'default');
   }
+  return hasWebsockets;
 }
 
 // Attempts to determine the absolute path of a script, minus the name of the

--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -67,12 +67,8 @@ function startTest(evt) {
   evt.preventDefault();
   createBackend();
   if (!isPluginLoaded()) {
-    $('#warning-plugin').show();
     return;
   }
-  $('#warning-plugin').hide();
-  $('#javaButton').attr('disabled', true);
-  $('#websocketButton').attr('disabled', true);
   showPage('test', resetGauges);
   $('#rttValue').html('');
   if (simulate) return simulateTest();
@@ -218,7 +214,6 @@ function setPhase(phase) {
       $('#jitter').html(printJitter(false));
       $('#test-details').html(testDetails());
       $('#test-advanced').append(testDiagnosis());
-      $('#javaButton').attr('disabled', false);
 
       showPage('results');
       break;
@@ -348,7 +343,7 @@ function updateGaugeValue() {
   }
 }
 
-// TESTING JAVA/WEBSOCKET CLIENT
+// TESTING WEBSOCKET CLIENT
 
 function testNDT() {
   if (websocket_client) {
@@ -556,29 +551,10 @@ function testDetails() {
   return d;
 }
 
-// BACKEND METHODS
-function useJavaAsBackend() {
-  $('#warning-websocket').hide();
-  $('#rtt').show();
-  $('#rttValue').show();
-
-  $('.warning-environment').innerHTML = '';
-
-  use_websocket_client = false;
-
-  $('#websocketButton').removeClass('active');
-  $('#javaButton').addClass('active');
-}
-
 function useWebsocketAsBackend() {
   $('#rtt').hide();
   $('#rttValue').hide();
-  $('#warning-websocket').show();
-
   use_websocket_client = true;
-
-  $('#javaButton').removeClass('active');
-  $('#websocketButton').addClass('active');
 }
 
 function createBackend() {
@@ -617,19 +593,8 @@ function isPluginLoaded() {
 }
 
 function checkInstalledPlugins() {
-  var hasJava = false;
   var hasWebsockets = false;
 
-  $('#warning-plugin').hide();
-  $('#warning-websocket').hide();
-
-  hasJava = true;
-  if (typeof deployJava !== 'undefined') {
-    if (deployJava.getJREs() == '') {
-      hasJava = false;
-    }
-  }
-  hasWebsockets = false;
   try {
     var ndt_js = new NDTjs();
     if (ndt_js.checkBrowserSupport()) {
@@ -639,19 +604,14 @@ function checkInstalledPlugins() {
     hasWebsockets = false;
   }
 
-  if (!hasWebsockets) {
-    $('#websocketButton').attr('disabled', true);
-  }
-
-  if (!hasJava) {
-    $('#javaButton').attr('disabled', true);
-  }
-
   if (hasWebsockets) {
     useWebsocketAsBackend();
   }
-  else if (hasJava) {
-    useJavaAsBackend();
+  else {
+    $('#no-websocket').show()
+    $('#startButton').attr('pointer-events', 'none');
+    $('#startButton').css('background-color', '#4d4d4d');
+    $('#startButton').css('cursor', 'default');
   }
 }
 

--- a/HTML5-frontend/script.js
+++ b/HTML5-frontend/script.js
@@ -26,7 +26,6 @@ var PHASE_RESULTS   = 5;
 
 
 // STATUS VARIABLES
-var use_websocket_client = true;
 var websocket_client = null;
 var currentPhase = PHASE_LOADING;
 var currentPage = 'welcome';
@@ -554,18 +553,9 @@ function testDetails() {
   return d;
 }
 
-function useWebsocketAsBackend() {
-  $('#rtt').hide();
-  $('#rttValue').hide();
-  use_websocket_client = true;
-}
-
 function createBackend() {
   $('#backendContainer').empty();
-
-  if (use_websocket_client) {
-    websocket_client = new NDTWrapper(window.ndtServer);
-  }
+  websocket_client = new NDTWrapper(window.ndtServer);
 }
 
 // UTILITIES
@@ -588,7 +578,8 @@ function checkInstalledPlugins() {
     hasWebsockets = false;
   }
   if (hasWebsockets) {
-    useWebsocketAsBackend();
+    $('#rtt').hide();
+    $('#rttValue').hide();
   }
   else {
     $('#no-websocket').show()

--- a/HTML5-frontend/style.css
+++ b/HTML5-frontend/style.css
@@ -32,13 +32,14 @@ a img {
 .header {
   margin: 10px;  
 }
-#warning-environment {
-  color: orange;
-  margin: 5px;
-}
-#warning-plugin, #warning-websocket {
+#no-websocket {
   color: red;
   margin: 5px;
+}
+#no-websocket {
+  color: red;
+  margin: 5px;
+  display: none;
 }
 .page {
   width: 640px;
@@ -119,7 +120,6 @@ h3 {
   background-color:gray;
   cursor: default;
 }
-
 
 /* Welcome page */
 

--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -12,7 +12,6 @@
     <script type="text/javascript" src="script.js"></script>
     <script type="text/javascript" src="ndt-browser-client.js"></script>
     <script type="text/javascript" src="ndt-wrapper.js"></script>
-    <script type="text/javascript" src="http://www.java.com/js/deployJava.js"></script>
     <script type="text/javascript">
     var simulate = false;
     var allowDebug = false;
@@ -27,25 +26,14 @@
 
     <p>The Network Diagnostic Tool (NDT) provides a sophisticated speed and diagnostic test. An NDT test reports more than just the upload and download speeds &mdash; it also attempts to determine what, if any, problems limited these speeds, differentiating between computer configuration and network infrastructure problems. While the diagnostic messages are most useful for expert users, they can also help novice users by allowing them to provide detailed trouble reports to their network&nbsp;administrator.</p>
 
-    <p>NDT can make use of either a Java plugin, or WebSockets to perform the test. Make sure that the method you choose is supported by your browser</p>
-    <div id="warning-environment">
-    </div>
-
-    <div id="warning-plugin">
-        <p>Selected plugin was not loaded properly. Make sure that you have proper plugin installed, and that it is not being blocked by your browser.</p>
-    </div>
-
-    <div id="warning-websocket">
-        <p>The WebSocket client currently in beta. Due to the nature of WebSocket support in various web browsers, the results may be notedly lower than those obtained with the Java plugin.</p>
-    </div>
-
-    <div>
-      <button id="javaButton" class="backendButton button" onclick="useJavaAsBackend()" type="button">Java</button>
-      <button id="websocketButton" class="backendButton button" onclick="useWebsocketAsBackend()" type="button">WebSockets<sup><small>Beta</small></sup></button>
-    </div>
+    <p>This NDT test uses WebSockets to perform the test. Most every modern browser should support running this test. If you are experiencing problems, make sure that your browser has javascript enabled and support WebSockets.</p>
 
     <div is="learn_more">
       <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="http://www.measurementlab.net/">Learn more about Measurement Lab</a>
+    </div>
+
+    <div id="no-websocket">
+      <p>Your browser does not appear to support WebSockets. Please check your browser configuration or try a different browser.</p>
     </div>
 
     </div>
@@ -53,7 +41,7 @@
       Initializing...
     </div>
     <div class="controls">
-      <a href="#test" class="start button">Start Test</a>
+      <a href="#test" id="startButton" class="start button">Start Test</a>
     </div>
   </div>
   <div id="test" class="page">

--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -26,7 +26,7 @@
 
     <p>The Network Diagnostic Tool (NDT) provides a sophisticated speed and diagnostic test. An NDT test reports more than just the upload and download speeds &mdash; it also attempts to determine what, if any, problems limited these speeds, differentiating between computer configuration and network infrastructure problems. While the diagnostic messages are most useful for expert users, they can also help novice users by allowing them to provide detailed trouble reports to their network&nbsp;administrator.</p>
 
-    <p>This NDT test uses WebSockets to perform the test. Most every modern browser should support running this test. If you are experiencing problems, make sure that your browser has javascript enabled and support WebSockets.</p>
+    <p>This NDT test uses <a href="https://en.wikipedia.org/wiki/WebSocket">WebSockets</a>. Most modern browsers should support running this test. If you are experiencing problems, make sure that your browser has javascript enabled and supports WebSockets.</p> 
 
     <div is="learn_more">
       <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="http://www.measurementlab.net/">Learn more about Measurement Lab</a>


### PR DESCRIPTION
M-Lab hasn't supported the Java NDT test for a long time. We no longer even sign the Java applet that is deployed with NDT. However, the webserver built into NDT still serves a page which gives the user the option to run a test using either the Java applet or the WebSocket client, additionally adding a scary red warning that the WebSocket client is "beta".

This PR removes both the Java and WebSocket buttons, leaving on a single "Start Test" button. If the user's browser doesn't support WebSockets a red warning message is displayed and the "Start Test" button is effectively disabled.

I'm sure that a vanishingly small number of people or things run NDT tests directly from the NDT sliver (e.g., [http://ndt.iupui.mlab1.den01.measurement-lab.org:7123](http://ndt.iupui.mlab1.den01.measurement-lab.org:7123)), so this PR should be safe, and additionally inline with how we run the rest of the platform.

Additionally, the presence of the Java bits in the HTML interface interfere with stress and E2E testing in the testbed, requiring the Ops person running the tests to [manually edit the HTML files in the NDT sliver](https://docs.google.com/document/d/1djHmmEljzoa8Hfv7QSXmv52Q42gMhgk13nWsUhJOvac/edit#heading=h.ss6rokgiul1r). Not only this error prone, but modifying files deployed by the RPM package will cause the `slicectrl` init script to fail to restart the NDT service when it notices that files have been changed. 

To see what these change look like on a live server, go to [http://ndt.iupui.mlab1.lga0t.measurement-lab.org:7123/](http://ndt.iupui.mlab1.lga0t.measurement-lab.org:7123/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/73)
<!-- Reviewable:end -->
