### PR TITLE
Travis for ndt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# Build NDT and run unit tests.
+# * Uses builder image from docker.io/measurementlab/ndt-builder.
+# * Mounts ~/ndt as the build directory.
+# * Executes unit tests within travis after build.  (In development)
+
+dist: trusty
+language: ruby
+
+services:
+  - docker
+
+before_install:
+
+cache:
+  directories:
+
+before_cache:
+
+before_script:
+
+script:
+# Build and run tests.
+  - docker pull measurementlab/ndt-builder:latest
+  - cd ${TRAVIS_BUILD_DIR}; 
+  - mkdir ndt
+  - docker run -v ${TRAVIS_BUILD_DIR}/ndt:/root/builder measurementlab/ndt-builder
+  - ls -l ${TRAVIS_BUILD_DIR}/ndt
+
+# TODO - execute unit tests that do not require web100.
+# TODO - collect coverage stats and export to coveralls.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,15 @@
 # Build NDT and run unit tests.
-# * Uses builder image from docker.io/measurementlab/ndt-builder.
-# * Mounts ~/ndt as the build directory.
-# * Executes unit tests within travis after build.  (In development)
+# * Uses docker build-tools container
+# * Executes unit tests within travis after build.
 
 dist: trusty
 language: ruby
-
 services:
-  - docker
-
-before_install:
-
-cache:
-  directories:
-
-before_cache:
-
-before_script:
+- docker
 
 script:
-# Build and run tests.
-  - docker pull measurementlab/ndt-builder:latest
-  - cd ${TRAVIS_BUILD_DIR}; 
-  - mkdir ndt
-  - docker run -v ${TRAVIS_BUILD_DIR}/ndt:/root/builder measurementlab/ndt-builder
-  - ls -l ${TRAVIS_BUILD_DIR}/ndt
+- docker pull gcr.io/mlab-pub/github-m-lab-builder:latest
+# Run basic unit tests that don't require web100
+- docker run gcr.io/mlab-pub/github-m-lab-builder /root/ndt_build_and_test.sh
 
-# TODO - execute unit tests that do not require web100.
 # TODO - collect coverage stats and export to coveralls.


### PR DESCRIPTION
Try again - first PR was to master instead of to dev branch.

Adds a travis integration for NDT build.
Currently uses a temporary builder container. Will update this once we have standardized on mlab-oti container registry, probably in a couple days.

Still need to hammer out (before pushing to master) a plan for whether or how this might be pushed upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/80)
<!-- Reviewable:end -->
