### PR TITLE
I2util

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,76 +191,31 @@ else
 fi
 
 
+#
+# configure I2util
+#
 AC_ARG_WITH(I2util,
 		AC_HELP_STRING([--with-I2util=<dir>],
 				[defaults to building I2util under NDT if exists]),
 		with_I2util=$withval, with_I2util=yes)		
 
-#
-# find I2util
-#
 I2UTILLDFLAGS=""
 I2UTILLIBS=""
 I2UTILLIBDEPS=""
 I2UTILLIBMAKE=""
 I2UTILINCS=""
 
-if test -n "$with_I2util" && test "$with_I2util" != "yes"; then
-	I2util_dir=${with_I2util}
-	case $I2util_dir in
-		/*) ;; # already an absolute path
-		*) I2util_dir="`pwd`/$I2util_dir" ;;
-	esac
-	I2util_include_dir=`dirname $with_I2util`/include
-	I2UTILINCS="-I$I2util_include_dir $I2UTILINCS"
-	I2UTILLDFLAGS="-L$I2util_dir $I2UTILLDFLAGS"
-	I2UTILLIBDEPS="$I2util_dir/libI2util.a"
+if test -d I2util/I2util; then
+	AC_CONFIG_SUBDIRS(I2util)
+	TOP_BUILD_DIRS="I2util $TOP_BUILD_DIRS"
+	I2util_dir='${top_srcdir}/I2util'
+	I2UTILINCS="-I$I2util_dir $I2UTILINCS"
+	I2UTILLDFLAGS="-L$I2util_dir/I2util $I2UTILLDFLAGS"
+	I2UTILLIBDEPS="$I2util_dir/I2util/libI2util.a"
+	I2UTILLIBMAKE="cd $I2util_dir; make"
+else
+	AC_MSG_FAILURE([I2util required to build NDT])
 fi
-
-# Save the old CFLAGS and LDFLAGS
-OLD_LDFLAGS="$LDFLAGS"
-OLD_CFLAGS="$CFLAGS"
-
-CFLAGS="$CFLAGS $I2UTILINCS"
-LDFLAGS="$CFLAGS $I2UTILLDFLAGS"
-
-AC_SEARCH_LIBS([I2AddrByNode],I2util, HAVE_I2UTIL_LIBS=1,HAVE_I2UTIL_LIBS=0)
-AC_CHECK_HEADERS([I2util/util.h I2util/conf.h], HAVE_I2UTIL_HEADERS=1,HAVE_I2UTIL_HEADERS=0)
-
-LDFLAGS="$OLD_LDFLAGS"
-CFLAGS="$OLD_CFLAGS"
-
-if test "$HAVE_I2UTIL_HEADERS" != "1" || test "$HAVE_I2UTIL_LIBS" != "1"; then
-	# now, check for sub-build/sub-configure
-	if test -d I2util/I2util; then
-		AC_CONFIG_SUBDIRS(I2util)
-		TOP_BUILD_DIRS="I2util $TOP_BUILD_DIRS"
-		I2util_dir='${top_srcdir}/I2util'
-		I2UTILINCS="-I$I2util_dir $I2UTILINCS"
-		I2UTILLDFLAGS="-L$I2util_dir/I2util $I2UTILLDFLAGS"
-		I2UTILLIBDEPS="$I2util_dir/I2util/libI2util.a"
-		I2UTILLIBMAKE="cd $I2util_dir; make"
-	else
-		AC_MSG_FAILURE([I2util required to build NDT])
-	fi
-
-        # Save the old CFLAGS and LDFLAGS
-	OLD_LDFLAGS="$LDFLAGS"
-	OLD_CFLAGS="$CFLAGS"
-
-        CFLAGS="$CFLAGS $I2UTILINCS"
-        LDFLAGS="$CFLAGS $I2UTILLDFLAGS"
-
-        AC_SEARCH_LIBS([I2AddrByNode],I2util, ,AC_MSG_ERROR([Couldn't find I2util library]))
-        AC_CHECK_HEADERS([I2util/util.h I2util/conf.h], ,AC_MSG_ERROR([Couldn't find I2util header files]), [AC_INCLUDES_DEFAULT])
-
-	LDFLAGS="$OLD_LDFLAGS"
-	CFLAGS="$OLD_CFLAGS"
-
-	I2UTILLIBS="$I2UTILLDFLAGS -lI2util"
-fi
-
-I2UTILLIBS="$I2UTILLDFLAGS -lI2util"
 
 AC_SUBST(I2UTILLDFLAGS)
 AC_SUBST(I2UTILLIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ endif
 
 bin_PROGRAMS =
 sbin_PROGRAMS = $(ADD_FAKEWWW)
-noinst_PROGRAMS = 
+noinst_PROGRAMS =
 TESTS =
 
 if HAVE_WEB100
@@ -60,7 +60,6 @@ if HAVE_PCAP_H
 if HAVE_SSL
 if HAVE_JANSSON
 sbin_PROGRAMS += web100srv
-TESTS += web100srv_unit_tests
 endif
 endif
 endif

--- a/src/web100srv.h
+++ b/src/web100srv.h
@@ -323,8 +323,6 @@ int tcp_stat_autotune(int sock, tcp_stat_agent* agent, tcp_stat_connection cn);
 int tcp_stat_init(char *VarFileName);
 void tcp_stat_middlebox(int sock, tcp_stat_agent* agent, tcp_stat_connection cn, char *results_keys,
                         size_t results_keys_strlen, char *results_values, size_t results_strlen);
-int tcp_stat_setbuff(int sock, tcp_stat_agent* agent, tcp_stat_connection cn,
-                   int autotune);/* Not used so no web10g version */
 void tcp_stat_get_data_recv(int sock, tcp_stat_agent* agent,
                             tcp_stat_connection cn, int count_vars);
 


### PR DESCRIPTION
This updates a few files to clean up handling of I2util submodule.  This has been messed up for a while, with redundant but different versions of the library, and ambiguity about what actually got linked.  It turns out that for recent builds, we have been linking a library that was installed on mlab_builder, rather than either of the downloaded libraries.

This update also triggered a strict lint problem in the web100 code, and caused the web100 test to be run in travis, breaking the travis results.  So this also fixes both of those.  It does mean that "make check" no longer runs the web100 tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/83)
<!-- Reviewable:end -->
