### PR TITLE
Removes web100srv unit testing from builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,7 +60,6 @@ if HAVE_PCAP_H
 if HAVE_SSL
 if HAVE_JANSSON
 sbin_PROGRAMS += web100srv
-TESTS += web100srv_unit_tests
 endif
 endif
 endif


### PR DESCRIPTION
Since we are probably never going to build NDT again on a machine with a web100-patched kernel, remove web100srv unit testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/89)
<!-- Reviewable:end -->
