### PR TITLE
Use canonical build image and local version of NDT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ script:
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
 - TEST_COMMIT=$( git rev-parse HEAD )
-- git clone --recursive https://github.com/m-lab/ndt-support.git
+- git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 - git submodule sync
+- git submodule update --init --recursive
 - ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,18 @@ script:
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
+# Clone ndt-support without cloning submodules.
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
+# Change the ndt-support submodule coniguration for ndt to point to the
+# $TRAVIS_BUILD_DIR (e.g. the current state of m-lab/ndt being tested by travis).
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+# Sync and update the new ndt-support submodule configuration, which clones all
+# submodules (now pulling ndt-support/ndt from $TRAVIS_BUILD_DIR).
 - git submodule sync
 - git submodule update --init --recursive
+# Checkout the current $TRAVIS_COMMIT and set the ndt-support submodule to
+# point to this commit.
 - ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 # submodules (now pulling ndt-support/ndt from $TRAVIS_BUILD_DIR).
 - git submodule sync
 - git submodule update --init --recursive
-# Checkout the current $TRAVIS_COMMIT and set the ndt-support submodule to
+# Checkout the current $TRAVIS_COMMIT and set the ndt-support/ndt submodule to
 # point to this commit.
 - ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,19 @@ services:
 
 script:
 
-# Temporarily use the git repo dev branch, instead of the google container registry.
-# TODO - update this once the GCR builder is up to date.
-- docker build -t build https://github.com/m-lab/builder.git#dev
-- docker run build /root/ndt_build_and_test.sh dev
+# Checkout ndt-support repo and replace the ndt submodule with the current ndt
+# $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- git clone --recursive https://github.com/m-lab/ndt-support.git
+- cd ndt-support
+- git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+- ( cd ndt && git checkout $TRAVIS_COMMIT )
+- git commit -a -m 'Local commit of changes so "git submodule update" works'
+
+# Build using the canonical build image and local ndt-support.
+- docker run -it -w /root/building
+    -v `pwd`:/root/building measurementlab/builder:production-1.0
+    bash -c "DISABLE_APPLET_SIGNING=1 ./package/slicebuild.sh iupui_ndt"
+- ls -lR build/slicebase-*
 
 #- docker pull gcr.io/mlab-pub/github-m-lab-builder:latest
 # Run basic unit tests that don't require web100

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ script:
 
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- TEST_COMMIT=$( git rev-parse HEAD )
 - git clone --recursive https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
-- ( cd ndt && git checkout $TRAVIS_COMMIT )
+- ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 
 # Build using the canonical build image and local ndt-support.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,12 @@ script:
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
-- TEST_COMMIT=$( git rev-parse HEAD )
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 - git submodule sync
 - git submodule update --init --recursive
-- ( cd ndt && git checkout $TEST_COMMIT )
+- ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 
 # Build using the canonical build image and local ndt-support.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 # Clone ndt-support without cloning submodules.
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
-# Change the ndt-support submodule coniguration for ndt to point to the
+# Change the ndt-support submodule configuration for ndt to point to the
 # $TRAVIS_BUILD_DIR (e.g. the current state of m-lab/ndt being tested by travis).
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 # Sync and update the new ndt-support submodule configuration, which clones all

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ script:
 
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- set -e
 - TEST_COMMIT=$( git rev-parse HEAD )
 - git clone --recursive https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+- git submodule sync
 - ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 


### PR DESCRIPTION
This change addresses build failures discovered in https://github.com/m-lab/ndt/pull/96

The original docker build and run of the ndt_build_and_test.sh script depends on `dev` branches in both the m-lab/builder and m-lab/ndt-support repositories.

This change removes the dependency on the builder repo (where the dev branch had been deleted) in favor of the pre-built canonical builder docker image, `measurementlab/builder:production-1.0`.

As well, this change uses the m-lab/ndt-support master repo and replaces the old ndt submodule reference with a local reference to the current TRAVIS_COMMIT.

The result of these changes is that changes to m-lab/ndt will be tested by building the m-lab/ndt-support package using the `measurementlab/builder:production-1.0` environment.

The build and test steps in `ndt_build_and_test.sh` are subsumed by the build step here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/97)
<!-- Reviewable:end -->
