### PR TITLE
Set the --queueingtest check to exit with code 5 when queueing is det…

### DIFF
--- a/src/node_tests/ndt_client.js
+++ b/src/node_tests/ndt_client.js
@@ -354,7 +354,8 @@ function ndt_coordinator(sock) {
                     // server always replies with at least one SRV_QUEUE
                     // message, so we only care if the wait is more than 0.
                     if (argv['queueingtest'] && body.msg > 0) {
-                        die("Received SRV_QUEUE with wait time. Server is queueing.");
+                        log(DEBUG, "Received SRV_QUEUE with wait time. Server is queueing.");
+                        process.exit(5);
                     }
                 }
                 log(DEBUG, "Got SRV_QUEUE. Ignoring and waiting for MSG_LOGIN");


### PR DESCRIPTION
Currently, when the --queueingtest invocation of ndt_client.js detects queueing, it exits with code 1, which is the same code as any other error condition under which ndt_client.js might exit/fail. This PR simply sets the script to exit with code 5 when the --queueingtest flag was specified and queueing is detected. This will allow us to identify the queueing condition uniquely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/103)
<!-- Reviewable:end -->
