### PR TITLE
 Prevent SEGV by checking value from json_read_map_value

### DIFF
--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -780,9 +780,18 @@ int test_s2c(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
     buff[msgLen] = 0;
     if (testOptions->connection_flags & JSON_SUPPORT) {
       jsonMsgValue = json_read_map_value(buff, DEFAULT_KEY);
-      strlcpy(buff, jsonMsgValue, sizeof(buff));
-      msgLen = strlen(buff);
-      free(jsonMsgValue);
+      if ( jsonMsgValue != NULL ) {
+        strlcpy(buff, jsonMsgValue, sizeof(buff));
+        msgLen = strlen(buff);
+        free(jsonMsgValue);
+      } else {
+        /* The client has sent a malformed message, that is now corrupt. We do
+         * not report an error to the client because some integrations respond
+         * to errors with a retry. Instead, we continue using an invalid value
+         * for s2cspd. */
+        buff[0] = 0;
+        strcpy(buff, "-1");
+      }
     }
     if (msgLen <= 0) {
       log_println(0, "Improper message");


### PR DESCRIPTION
This change includes a fix for segfaults in the NDT server for some clients that send incorrect message headers.

Using pcap traces we've observed that some clients send a message header hex: 05 00 07, followed by a message str: `{"msg": "81034.0"}`. The header sends a length of 7 but the actual message is 17 characters long. As a result, the `json_read_map_value` fails. However, the original logic did not check the return value (`NULL`) which resulted in a SEGV during `strlcpy`.

This change checks the return value and assigns an invalid default value `-1` for the client-reported speed instead of reporting an error to the client because we believe these clients are deployed in a manner that they repeat tests after an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/106)
<!-- Reviewable:end -->
