### PR TITLE
Update www.measurementlab.net links to HTTPS

### DIFF
--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -29,7 +29,7 @@
     <p>This NDT test uses <a href="https://en.wikipedia.org/wiki/WebSocket">WebSockets</a>. Most modern browsers should support running this test. If you are experiencing problems, make sure that your browser has javascript enabled and supports WebSockets.</p> 
 
     <div is="learn_more">
-      <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="http://www.measurementlab.net/">Learn more about Measurement Lab</a>
+      <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="https://www.measurementlab.net/">Learn more about Measurement Lab</a>
     </div>
 
     <div id="no-websocket">
@@ -135,4 +135,3 @@
 
 </body>
 </html>
-

--- a/flash-client/src/NDTConstants.as
+++ b/flash-client/src/NDTConstants.as
@@ -14,7 +14,7 @@
 
 package  {
   public class NDTConstants {
-    public static const MLAB_SITE:String = "http://www.measurementlab.net";
+    public static const MLAB_SITE:String = "https://www.measurementlab.net";
 
     public static const CLIENT_VERSION:String = CONFIG::clientVersion;
     public static const EXPECTED_SERVER_VERSION:String = CONFIG::serverVersion;
@@ -250,4 +250,3 @@ package  {
         + "to obtain precise measurements.";
   }
 }
-


### PR DESCRIPTION
Per https://github.com/m-lab/m-lab.github.io/issues/166, it looks like M-Lab prefers HTTPS links to its website. Should they be updated here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt/108)
<!-- Reviewable:end -->
